### PR TITLE
Add Pyodide worker service

### DIFF
--- a/MCP-TODO.md
+++ b/MCP-TODO.md
@@ -1,0 +1,124 @@
+Purpose & Intent
+
+Implement Chrome Tools MCP Server as our browser–→LLM bridge so that Cursor’s Composer agent can ingest live console.log, network, and DOM events directly from Chrome DevTools. This removes manual copy-paste, enables autonomous debugging loops, and future-proofs our observability stack for any IDE or agent that speaks the Model-Context-Protocol (MCP). (github.com, pulsemcp.com)
+
+Why Chrome Tools over BrowserTools? Chrome Tools MCP is lightweight (no extension), scriptable via Node, and offers deeper DevTools Protocol access—critical for CI headless runs and custom filtering of noisy logs. (github.com, docs.cursor.com)
+
+⸻
+
+Implementation Checklist
+
+0. Pre-flight
+	•	Confirm Node ≥ 16 and npm are installed. (node -v, npm -v) (kento-yamazaki.medium.com)
+	•	Verify Chrome/Chromium version ≥ 115 (stable CDP v1.3). (github.com)
+
+1. Launch Chrome with Remote Debugging
+	•	Mac / Linux:
+
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
+  --remote-debugging-port=9222 --user-data-dir=/tmp/mcp-profile
+
+
+	•	Windows:
+
+"C:\Program Files\Google\Chrome\Application\chrome.exe" --remote-debugging-port=9222
+
+Rationale – Chrome Tools MCP connects via CDP at http://localhost:9222. Without this flag the server cannot attach. (github.com)
+
+2. Install Chrome Tools MCP
+	•	Add as dev dependency:
+
+npm install -D @nicholmikey/chrome-tools
+
+Alternately: npm i -g @nicholmikey/chrome-tools for global CLI use. (github.com)
+
+3. Create mcp.json for Cursor
+	•	Inside project root, create .cursor/mcp.json with:
+
+{
+  "mcpServers": {
+    "chrome-tools": {
+      "command": "node",
+      "args": [
+        "./node_modules/@nicholmikey/chrome-tools/dist/index.js"
+      ],
+      "env": {
+        "CHROME_DEBUG_URL": "http://localhost:9222",
+        "CHROME_CONNECTION_TYPE": "direct"
+      },
+      "enabled": true
+    }
+  }
+}
+
+For Windows CMD + npx variant see Appendix A. (reddit.com, forum.cursor.com)
+
+4. Add NPM script for local runs
+	•	In package.json:
+
+{
+  "scripts": {
+    "mcp:chrome": "node ./node_modules/@nicholmikey/chrome-tools/dist/index.js"
+  }
+}
+
+This lets devs run npm run mcp:chrome during non-Cursor sessions. (eekayonline.medium.com)
+
+5. Verify Connectivity
+	•	Start Chrome with flag (Step 1).
+	•	Run npm run mcp:chrome (or let Cursor auto-spawn).
+	•	Open DevTools ➜ Remote Target (chrome://inspect/#devices) – ensure port 9222 is exposed. (reddit.com)
+	•	In Cursor, send: chrome-tools.list_tabs – should return active tab array. (github.com)
+
+6. Capture Console Logs in Agent Flow
+	•	From Cursor chat, invoke:
+
+{
+  "tool": "chrome-tools.capture_console",
+  "args": { "tabId": <TAB_ID>, "duration": 10 }
+}
+
+Check that console.log lines appear in chat timeline. (github.com)
+
+7. Noise-Reduction Filters (Optional)
+	•	Set CHROME_CONSOLE_LEVEL env (error|warn|info|log).
+	•	Implement custom regex ignore list in ENV.IGNORE_PATTERNS (supported since v0.3.4). (github.com)
+
+8. Security Hardening
+	•	Ensure secrets never hit console; if unavoidable set REDACT_PATTERNS env to auto-mask tokens. (github.com)
+	•	Restrict CDP port to loopback or secure tunnel in CI (SSH / ngrok). (github.com)
+
+9. Continuous Integration (Headless)
+	•	Add a Docker service using chromedp/headless-shell exposing 9222. (github.com)
+	•	Spawn MCP server in the same job; export CHROME_CONNECTION_TYPE=docker.
+	•	Run test suite; parse screenshots in artifacts. (forum.cursor.com)
+
+10. Documentation & Onboarding
+	•	Link this file in CONTRIBUTING.md.
+	•	Record 2-minute Loom demo; store in /docs/videos.
+	•	PR reviewers must verify steps 1–6.
+
+⸻
+
+Appendix A – Windows npx Shortcut
+
+{
+  "mcpServers": {
+    "chrome-tools": {
+      "command": "cmd.exe",
+      "args": [
+        "/c",
+        "npx",
+        "-y",
+        "@nicholmikey/chrome-tools"
+      ],
+      "enabled": true
+    }
+  }
+}
+
+(reddit.com)
+
+⸻
+
+Last updated: 2025-05-16

--- a/execution-service.js
+++ b/execution-service.js
@@ -1,0 +1,35 @@
+class ExecutionService {
+  constructor() {
+    this.worker = new Worker('python-worker.js');
+    this.ready = new Promise((resolve) => {
+      const listener = (event) => {
+        if (event.data === 'ready') {
+          this.worker.removeEventListener('message', listener);
+          resolve();
+        }
+      };
+      this.worker.addEventListener('message', listener);
+    });
+  }
+
+  async run(code) {
+    await this.ready;
+    return new Promise((resolve, reject) => {
+      const id = Math.random().toString(36).substring(2);
+      const handler = (event) => {
+        if (event.data.id === id) {
+          this.worker.removeEventListener('message', handler);
+          if (event.data.error) {
+            reject(event.data.error);
+          } else {
+            resolve(event.data.result);
+          }
+        }
+      };
+      this.worker.addEventListener('message', handler);
+      this.worker.postMessage({ id, code });
+    });
+  }
+}
+
+window.ExecutionService = ExecutionService;

--- a/index.html
+++ b/index.html
@@ -15,7 +15,11 @@
   <textarea id="code" placeholder="Code editor placeholder..."></textarea>
   <br />
   <button id="run">Sort Random Array</button>
+  <button id="py-run">Sort with Python + WASM</button>
   <div id="visualization"></div>
+  <!-- Pyodide makes it possible to run Python in the browser -->
+  <script src="https://cdn.jsdelivr.net/pyodide/v0.23.4/full/pyodide.js"></script>
+  <script src="execution-service.js"></script>
   <script src="main.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -19,7 +19,9 @@ function visualize(arr) {
 
 loadWasm().then(exports => {
   const { memory, bubble_sort, __heap_base } = exports;
+  const pyService = new ExecutionService();
   const button = document.getElementById('run');
+  const pyButton = document.getElementById('py-run');
   button.addEventListener('click', () => {
     const length = 10;
     const heapBase = __heap_base.value;
@@ -30,5 +32,17 @@ loadWasm().then(exports => {
     visualize(arr);
     bubble_sort(heapBase, length);
     setTimeout(() => visualize(arr), 100);
+  });
+
+  pyButton?.addEventListener('click', async () => {
+    const length = 10;
+    const arr = Array.from({ length }, () => Math.floor(Math.random() * 100));
+    visualize(arr);
+    try {
+      const result = await pyService.run(`wasm_sort(${JSON.stringify(arr)})`);
+      visualize(result);
+    } catch (err) {
+      console.error(err);
+    }
   });
 });

--- a/python-worker.js
+++ b/python-worker.js
@@ -1,0 +1,35 @@
+importScripts('https://cdn.jsdelivr.net/pyodide/v0.23.4/full/pyodide.js');
+
+async function loadWasm() {
+  const response = await fetch('bubble.wasm');
+  const bytes = await response.arrayBuffer();
+  const { instance } = await WebAssembly.instantiate(bytes, {});
+  const { memory, bubble_sort, __heap_base } = instance.exports;
+
+  return function wasmSort(array) {
+    const ptr = __heap_base.value;
+    const buf = new Int32Array(memory.buffer, ptr, array.length);
+    buf.set(array);
+    bubble_sort(ptr, array.length);
+    return Array.from(buf);
+  };
+}
+
+const pyodideReady = loadPyodide();
+const wasmReady = loadWasm();
+
+Promise.all([pyodideReady, wasmReady]).then(([pyodide, wasmSort]) => {
+  pyodide.globals.set('wasm_sort', wasmSort);
+  self.postMessage('ready');
+});
+
+self.onmessage = async (event) => {
+  await Promise.all([pyodideReady, wasmReady]);
+  const { id, code } = event.data;
+  try {
+    let result = await self.pyodide.runPythonAsync(code);
+    self.postMessage({ id, result });
+  } catch (err) {
+    self.postMessage({ id, error: err.toString() });
+  }
+};

--- a/src/app/execution.service.ts
+++ b/src/app/execution.service.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@angular/core';
+
+export interface ExecutionResult {
+  id: string;
+  result?: any;
+  error?: string;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ExecutionService {
+  private worker: Worker;
+  private ready: Promise<void>;
+
+  constructor() {
+    if (typeof Worker === 'undefined') {
+      throw new Error('Web Workers are not supported in this environment.');
+    }
+    // The worker will load Pyodide and notify when ready
+    this.worker = new Worker(new URL('./python-worker.ts', import.meta.url));
+    this.ready = new Promise<void>(resolve => {
+      const listener = (event: MessageEvent) => {
+        if (event.data === 'ready') {
+          this.worker.removeEventListener('message', listener);
+          resolve();
+        }
+      };
+      this.worker.addEventListener('message', listener);
+    });
+  }
+
+  async run(code: string): Promise<any> {
+    await this.ready;
+    return new Promise((resolve, reject) => {
+      const id = Math.random().toString(36).substring(2);
+      const handler = (event: MessageEvent<ExecutionResult>) => {
+        if (event.data.id === id) {
+          this.worker.removeEventListener('message', handler as any);
+          if (event.data.error) {
+            reject(event.data.error);
+          } else {
+            resolve(event.data.result);
+          }
+        }
+      };
+      this.worker.addEventListener('message', handler as any);
+      this.worker.postMessage({ id, code });
+    });
+  }
+}

--- a/src/app/python-worker.ts
+++ b/src/app/python-worker.ts
@@ -1,0 +1,36 @@
+// Web Worker that loads Pyodide and executes Python code
+importScripts('https://cdn.jsdelivr.net/pyodide/v0.23.4/full/pyodide.js');
+
+async function loadWasm() {
+  const response = await fetch('bubble.wasm');
+  const bytes = await response.arrayBuffer();
+  const { instance } = await WebAssembly.instantiate(bytes, {});
+  const { memory, bubble_sort, __heap_base } = instance.exports as any;
+
+  return function wasmSort(array: number[]): number[] {
+    const ptr = (__heap_base as WebAssembly.Global).value;
+    const buf = new Int32Array(memory.buffer, ptr, array.length);
+    buf.set(array);
+    (bubble_sort as Function)(ptr, array.length);
+    return Array.from(buf);
+  };
+}
+
+const pyodideReady = loadPyodide();
+const wasmReady = loadWasm();
+
+Promise.all([pyodideReady, wasmReady]).then(([pyodide, wasmSort]) => {
+  (pyodide as any).globals.set('wasm_sort', wasmSort);
+  self.postMessage('ready');
+});
+
+self.onmessage = async (event) => {
+  await Promise.all([pyodideReady, wasmReady]);
+  const { id, code } = event.data;
+  try {
+    const result = await (self as any).pyodide.runPythonAsync(code);
+    self.postMessage({ id, result });
+  } catch (err) {
+    self.postMessage({ id, error: err.toString() });
+  }
+};


### PR DESCRIPTION
## Summary
- load Pyodide via script tag
- add ExecutionService to run Python in a Web Worker
- create worker that initializes Pyodide and executes code
- expose `wasm_sort` helper that uses the existing WebAssembly bubble sort
- demo Python-powered sort on the page

## Testing
- `node --version`
