### PR TITLE
Add run-length encoding visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This project contains small interactive demos for various data structure and algorithm patterns.
 
-Currently the project includes visualizations for the sliding window, two pointers, and prefix sum techniques. A small navigation bar lets you switch between demos.
+Currently the project includes visualizations for the sliding window, two pointers, prefix sum, and run-length encoding techniques. A small navigation bar lets you switch between demos.
 
 ## Running Locally
 
@@ -10,7 +10,7 @@ No build step is required. Simply open one of the HTML files in `src` in any mod
 
 1. Clone the repository.
 2. Navigate to the project directory.
-3. Open any of `src/index.html` (sliding window), `src/two_pointers.html` (two pointers), or `src/prefix_sum.html` (prefix sum) in your browser.
+3. Open any of `src/index.html` (sliding window), `src/two_pointers.html` (two pointers), `src/prefix_sum.html` (prefix sum), or `src/run_length_encoding.html` (run-length encoding) in your browser.
 
 You should see controls to start, pause, and reset the selected visualization.
 

--- a/TODO.md
+++ b/TODO.md
@@ -12,7 +12,7 @@ Implement demos for:
 - A-01 Sliding Window
 - A-02 Two Pointers
 - ~~A-03 Prefix Sum / Difference Array~~
-- A-04 Run-Length Encoding
+- ~~A-04 Run-Length Encoding~~
 - A-05 Dutch National Flag (3-way partition)
 - A-06 Rolling Hash / Rabin-Karp
 - A-07 Z-Algorithm (Z-Function)

--- a/src/index.html
+++ b/src/index.html
@@ -9,7 +9,8 @@
     <nav>
         <a href="index.html">Sliding Window</a> |
         <a href="two_pointers.html">Two Pointers</a> |
-        <a href="prefix_sum.html">Prefix Sum</a>
+        <a href="prefix_sum.html">Prefix Sum</a> |
+        <a href="run_length_encoding.html">Run-Length Encoding</a>
     </nav>
     <h1>Sliding Window Demo</h1>
     <p>Enter numbers separated by commas and choose a window size.</p>

--- a/src/prefix_sum.html
+++ b/src/prefix_sum.html
@@ -9,7 +9,8 @@
     <nav>
         <a href="index.html">Sliding Window</a> |
         <a href="two_pointers.html">Two Pointers</a> |
-        <a href="prefix_sum.html">Prefix Sum</a>
+        <a href="prefix_sum.html">Prefix Sum</a> |
+        <a href="run_length_encoding.html">Run-Length Encoding</a>
     </nav>
     <h1>Prefix Sum Demo</h1>
     <p>Enter numbers separated by commas to see their prefix sums.</p>

--- a/src/run_length_encoding.html
+++ b/src/run_length_encoding.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Run-Length Encoding Demo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <nav>
+        <a href="index.html">Sliding Window</a> |
+        <a href="two_pointers.html">Two Pointers</a> |
+        <a href="prefix_sum.html">Prefix Sum</a> |
+        <a href="run_length_encoding.html">Run-Length Encoding</a>
+    </nav>
+    <h1>Run-Length Encoding Demo</h1>
+    <p>Enter a string to compress with run-length encoding.</p>
+    <input id="rleInput" value="aaabccccdd" style="width:300px" />
+    <button id="rleStartBtn">Start</button>
+    <button id="rlePauseBtn">Pause</button>
+    <button id="rleResetBtn">Reset</button>
+    <div id="rleOriginalContainer"></div>
+    <div id="rleEncodedContainer" style="margin-top:20px"></div>
+    <script src="run_length_encoding.js"></script>
+</body>
+</html>

--- a/src/run_length_encoding.js
+++ b/src/run_length_encoding.js
@@ -1,0 +1,74 @@
+const rleInput = document.getElementById('rleInput');
+const rleStartBtn = document.getElementById('rleStartBtn');
+const rlePauseBtn = document.getElementById('rlePauseBtn');
+const rleResetBtn = document.getElementById('rleResetBtn');
+const rleOriginalContainer = document.getElementById('rleOriginalContainer');
+const rleEncodedContainer = document.getElementById('rleEncodedContainer');
+
+let rleIntervalId = null;
+let rleIndex = 0;
+let rleStr = '';
+let rleOutput = '';
+let rleCount = 0;
+
+function rleRender() {
+    rleOriginalContainer.innerHTML = '';
+    for (let i = 0; i < rleStr.length; i++) {
+        const div = document.createElement('div');
+        div.className = 'array-item';
+        div.textContent = rleStr[i];
+        if (i === rleIndex) {
+            div.classList.add('active');
+        }
+        rleOriginalContainer.appendChild(div);
+    }
+    rleEncodedContainer.textContent = rleOutput + (rleCount > 0 ? rleStr[rleIndex] + rleCount : '');
+}
+
+function rleStep() {
+    const char = rleStr[rleIndex];
+    if (rleIndex === 0 || char === rleStr[rleIndex - 1]) {
+        rleCount++;
+    } else {
+        rleOutput += rleStr[rleIndex - 1] + rleCount;
+        rleCount = 1;
+    }
+    rleRender();
+    rleIndex++;
+    if (rleIndex >= rleStr.length) {
+        rleOutput += rleStr[rleIndex - 1] + rleCount;
+        rleRender();
+        rlePause();
+    }
+}
+
+function rleStart() {
+    rleStr = rleInput.value || '';
+    rleOutput = '';
+    rleCount = 0;
+    rleIndex = 0;
+    rleRender();
+    rlePause();
+    rleIntervalId = setInterval(rleStep, 800);
+}
+
+function rlePause() {
+    if (rleIntervalId) {
+        clearInterval(rleIntervalId);
+        rleIntervalId = null;
+    }
+}
+
+function rleReset() {
+    rlePause();
+    rleIndex = 0;
+    rleOutput = '';
+    rleCount = 0;
+    rleRender();
+}
+
+rleStartBtn.addEventListener('click', rleStart);
+rlePauseBtn.addEventListener('click', rlePause);
+rleResetBtn.addEventListener('click', rleReset);
+
+rleRender();

--- a/src/two_pointers.html
+++ b/src/two_pointers.html
@@ -9,7 +9,8 @@
     <nav>
         <a href="index.html">Sliding Window</a> |
         <a href="two_pointers.html">Two Pointers</a> |
-        <a href="prefix_sum.html">Prefix Sum</a>
+        <a href="prefix_sum.html">Prefix Sum</a> |
+        <a href="run_length_encoding.html">Run-Length Encoding</a>
     </nav>
     <h1>Two Pointers Demo</h1>
     <p>Enter sorted numbers separated by commas and a target sum.</p>


### PR DESCRIPTION
## Summary
- implement Run-Length Encoding page with animation controls
- add navigation link to the new demo
- document the new page in the README
- mark the roadmap task as done

## Testing
- `git status --short`